### PR TITLE
Fix issues with connecting to other databases

### DIFF
--- a/src/main/java/liquibase/ext/cosmosdb/database/CosmosConnection.java
+++ b/src/main/java/liquibase/ext/cosmosdb/database/CosmosConnection.java
@@ -23,6 +23,7 @@ package liquibase.ext.cosmosdb.database;
 import com.azure.cosmos.CosmosDatabase;
 import liquibase.exception.DatabaseException;
 import liquibase.nosql.database.AbstractNoSqlConnection;
+import liquibase.util.StringUtil;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -32,10 +33,7 @@ import java.util.Properties;
 
 import static java.util.Objects.isNull;
 import static java.util.Optional.ofNullable;
-import static liquibase.ext.cosmosdb.database.CosmosConnectionString.ACCOUNT_ENDPOINT_PROPERTY;
-import static liquibase.ext.cosmosdb.database.CosmosConnectionString.ACCOUNT_KEY_PROPERTY;
-import static liquibase.ext.cosmosdb.database.CosmosConnectionString.DATABASE_NAME_PROPERTY;
-import static liquibase.ext.cosmosdb.database.CosmosConnectionString.fromConnectionString;
+import static liquibase.ext.cosmosdb.database.CosmosConnectionString.*;
 
 @Getter
 @Setter
@@ -134,6 +132,11 @@ public class CosmosConnection extends AbstractNoSqlConnection {
         } catch (final Exception e) {
             throw new DatabaseException("Could not create database: " + databaseName, e);
         }
+    }
+
+    @Override
+    public boolean supports(String url) {
+        return !StringUtil.isEmpty(StringUtil.trimToNull(url)) && url.startsWith(COSMOSDB_PREFIX);
     }
 
     @Override

--- a/src/main/java/liquibase/nosql/executor/NoSqlExecutor.java
+++ b/src/main/java/liquibase/nosql/executor/NoSqlExecutor.java
@@ -25,6 +25,7 @@ import liquibase.changelog.ChangeLogHistoryServiceFactory;
 import liquibase.database.Database;
 import liquibase.exception.DatabaseException;
 import liquibase.executor.AbstractExecutor;
+import liquibase.ext.cosmosdb.database.CosmosLiquibaseDatabase;
 import liquibase.logging.Logger;
 import liquibase.nosql.changelog.AbstractNoSqlHistoryService;
 import liquibase.nosql.database.AbstractNoSqlConnection;
@@ -66,6 +67,11 @@ public class NoSqlExecutor extends AbstractExecutor {
     @Override
     public String getName() {
         return EXECUTOR_NAME;
+    }
+
+    @Override
+    public boolean supports(Database database) {
+        return database instanceof CosmosLiquibaseDatabase;
     }
 
     @Override


### PR DESCRIPTION
Because the NoSqlExector didn't implement the `supports()` method, when this extension is installed the NoSqlExecutor gets used for ALL databases not just CosmosDB.

This PR adds the needed supports method. 
