### PR TITLE
Do not include the master key in the connection exception

### DIFF
--- a/src/main/java/liquibase/ext/cosmosdb/database/CosmosClientDriver.java
+++ b/src/main/java/liquibase/ext/cosmosdb/database/CosmosClientDriver.java
@@ -34,8 +34,13 @@ public class CosmosClientDriver implements Driver {
                     .userAgentSuffix(LIQUIBASE_EXTENSION_USER_AGENT_SUFFIX)
                     .buildClient();
         } catch (final Exception e) {
-            throw new DatabaseException("Connection could not be established to: "
-                    + cosmosConnectionString.getConnectionString(), e);
+            final String message = String.format(
+                    "Connection could not be established to endpoint: %s, database: %s",
+                    cosmosConnectionString.getAccountEndpoint(),
+                    cosmosConnectionString.getDatabaseName()
+            );
+
+            throw new DatabaseException(message, e);
         }
         return CosmosClientProxy.builder().cosmosClient(client).build();
     }

--- a/src/test/java/liquibase/ext/cosmosdb/database/CosmosClientDriverTest.java
+++ b/src/test/java/liquibase/ext/cosmosdb/database/CosmosClientDriverTest.java
@@ -5,8 +5,6 @@ import liquibase.ext.cosmosdb.TestUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Objects;
 import java.util.Properties;
@@ -16,7 +14,6 @@ import java.util.regex.Pattern;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@ExtendWith(MockitoExtension.class)
 class CosmosClientDriverTest {
     static final Pattern DB_CONNECTION_URI_PATTERN = Pattern.compile("^(.+:).+(@.+)$");
     static final String MASTER_KEY = "test_master_key";

--- a/src/test/java/liquibase/ext/cosmosdb/database/CosmosClientDriverTest.java
+++ b/src/test/java/liquibase/ext/cosmosdb/database/CosmosClientDriverTest.java
@@ -1,0 +1,50 @@
+package liquibase.ext.cosmosdb.database;
+
+import liquibase.exception.DatabaseException;
+import liquibase.ext.cosmosdb.TestUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Objects;
+import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ExtendWith(MockitoExtension.class)
+class CosmosClientDriverTest {
+    static final Pattern DB_CONNECTION_URI_PATTERN = Pattern.compile("^(.+:).+(@.+)$");
+    static final String MASTER_KEY = "test_master_key";
+
+    CosmosClientDriver cosmosClientDriver;
+    String invalidDbConnectionUri;
+
+    @BeforeEach
+    void beforeEach() {
+        cosmosClientDriver = new CosmosClientDriver();
+
+        final Properties properties = TestUtils.loadProperties();
+        final String dbConnectionUri = properties.getProperty(TestUtils.DB_CONNECTION_URI_PROPERTY);
+        final Matcher matcher = DB_CONNECTION_URI_PATTERN.matcher(dbConnectionUri);
+        if (matcher.matches()) {
+            invalidDbConnectionUri = matcher.group(1) + MASTER_KEY + matcher.group(2);
+        }
+
+        Objects.requireNonNull(invalidDbConnectionUri, "Error constructing invalid database connection URI.");
+    }
+
+    @Nested
+    class when_connect_is_invoked {
+        @Test
+        void given_a_CosmosClientBuilder_exception_then_a_DatabaseException_is_thrown_with_a_message_not_containing_the_master_key() {
+            final CosmosConnectionString cosmosConnectionString = CosmosConnectionString.fromConnectionString(invalidDbConnectionUri);
+            final DatabaseException databaseException = assertThrows(DatabaseException.class, () -> cosmosClientDriver.connect(cosmosConnectionString));
+            assertThat(databaseException).hasMessageNotContaining(MASTER_KEY);
+        }
+    }
+}


### PR DESCRIPTION
* See #214.

* Do not include the master key in the connection exception. Rather,
  only include the endpoint and database.

* I added two commits where checking out the first commit and running the build will show the test failing. Checking out the second commit will show the test passing.