### PR TITLE
chore(workflows): update build logic workflows to version v0.5.8

### DIFF
--- a/.github/workflows/attach-artifact-release.yml
+++ b/.github/workflows/attach-artifact-release.yml
@@ -8,5 +8,5 @@ on:
 jobs:
 
   attach-artifact-to-release:
-    uses: liquibase/build-logic/.github/workflows/extension-attach-artifact-release.yml@v0.5.7
+    uses: liquibase/build-logic/.github/workflows/extension-attach-artifact-release.yml@v0.5.8
     secrets: inherit

--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -2,12 +2,13 @@
 name: "Nightly build"
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: '0 7 * * 1-5'
 
 jobs:
     nightly-build:
-      uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@v0.5.7
+      uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@v0.5.8
       with:
         nightly: true
       secrets: inherit

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   codeql:
-    uses: liquibase/build-logic/.github/workflows/codeql.yml@v0.5.7
+    uses: liquibase/build-logic/.github/workflows/codeql.yml@v0.5.8
     secrets: inherit
     with:
       languages: '["java"]'

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -8,5 +8,5 @@ on:
 
 jobs:
   create-release:
-    uses: liquibase/build-logic/.github/workflows/create-release.yml@v0.5.7
+    uses: liquibase/build-logic/.github/workflows/create-release.yml@v0.5.8
     secrets: inherit

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -7,5 +7,5 @@ on:
 
 jobs:
   release:
-    uses: liquibase/build-logic/.github/workflows/extension-release-published.yml@v0.5.7
+    uses: liquibase/build-logic/.github/workflows/extension-release-published.yml@v0.5.8
     secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,10 +16,10 @@ jobs:
 
   build-test:
     needs: authorize
-    uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@v0.5.7
+    uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@v0.5.8
     secrets: inherit
 
   dependabot:
     needs: build-test
-    uses: liquibase/build-logic/.github/workflows/dependabot-automerge.yml@v0.5.7
+    uses: liquibase/build-logic/.github/workflows/dependabot-automerge.yml@v0.5.8
     secrets: inherit


### PR DESCRIPTION
The build logic workflows in the `.github/workflows` directory have been updated to use version v0.5.8 of the build logic. This update includes bug fixes and improvements to the workflows.