### PR TITLE
feat: Add Azure Identity support for Cosmos DB authentication

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,11 @@
             <version>${mockito-junit-jupiter.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-identity</artifactId>
+            <version>1.18.4</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/liquibase/ext/cosmosdb/database/CosmosClientDriver.java
+++ b/src/main/java/liquibase/ext/cosmosdb/database/CosmosClientDriver.java
@@ -1,8 +1,10 @@
 package liquibase.ext.cosmosdb.database;
 
+import com.azure.core.credential.TokenCredential;
 import com.azure.cosmos.ConsistencyLevel;
 import com.azure.cosmos.CosmosClient;
 import com.azure.cosmos.CosmosClientBuilder;
+import com.azure.identity.DefaultAzureCredentialBuilder;
 import liquibase.Scope;
 import liquibase.exception.DatabaseException;
 import liquibase.util.StringUtil;
@@ -27,12 +29,18 @@ public class CosmosClientDriver implements Driver {
     public CosmosClientProxy connect(final CosmosConnectionString cosmosConnectionString) throws DatabaseException {
         final CosmosClient client;
         try {
-            client = new CosmosClientBuilder()
-                    .endpoint(cosmosConnectionString.getAccountEndpoint().orElse(""))
-                    .key(cosmosConnectionString.getAccountKey().orElse(""))
-                    .consistencyLevel(ConsistencyLevel.EVENTUAL)
-                    .userAgentSuffix(LIQUIBASE_EXTENSION_USER_AGENT_SUFFIX)
-                    .buildClient();
+            if (cosmosConnectionString.getUseAzureIdentity().orElse("").equals("true")) {
+                TokenCredential credential = new DefaultAzureCredentialBuilder()
+                        .build();
+                client = new CosmosClientBuilder().credential(credential).buildClient();
+            } else {
+                client = new CosmosClientBuilder()
+                        .endpoint(cosmosConnectionString.getAccountEndpoint().orElse(""))
+                        .key(cosmosConnectionString.getAccountKey().orElse(""))
+                        .consistencyLevel(ConsistencyLevel.EVENTUAL)
+                        .userAgentSuffix(LIQUIBASE_EXTENSION_USER_AGENT_SUFFIX)
+                        .buildClient();
+            }
         } catch (final Exception e) {
             final String message = String.format(
                     "Connection could not be established to endpoint: %s, database: %s",

--- a/src/main/java/liquibase/ext/cosmosdb/database/CosmosConnectionString.java
+++ b/src/main/java/liquibase/ext/cosmosdb/database/CosmosConnectionString.java
@@ -21,6 +21,7 @@ public class CosmosConnectionString {
     public static final String ACCOUNT_ENDPOINT_PROPERTY = "accountEndpoint";
     public static final String ACCOUNT_KEY_PROPERTY = "accountKey";
     public static final String DATABASE_NAME_PROPERTY = "databaseName";
+    public static final String USE_AZURE_IDENTITY_PROPERTY = "useAzureIdentity";
 
     public static final String COSMOSDB_PREFIX = "cosmosdb://";
     public static final String COSMOSDB_JSON_PREFIX = COSMOSDB_PREFIX + "{";
@@ -123,6 +124,10 @@ public class CosmosConnectionString {
 
     public Optional<String> getDatabaseName() {
         return getProperty(DATABASE_NAME_PROPERTY);
+    }
+
+    public Optional<String> getUseAzureIdentity() {
+        return getProperty(USE_AZURE_IDENTITY_PROPERTY);
     }
 
 }


### PR DESCRIPTION
This enables connecting to Cosmos DB using DefaultAzureCredential via the `useAzureIdentity=true` connection string property. This allows for more secure, passwordless authentication using various Azure AD-based mechanisms like Managed Identities, eliminating the need to directly provide account keys.