### PR TITLE
fix: migrate IT execution from surefire to failsafe so -DskipITs works

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,18 +93,25 @@
                             </includes>
                         </configuration>
                     </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>${maven-surefire-plugin.version}</version>
+                <configuration>
+                    <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                    <reportFormat>plain</reportFormat>
+                    <includes>
+                        <include>**/*IT.java</include>
+                    </includes>
+                </configuration>
+                <executions>
                     <execution>
                         <id>integration-tests</id>
-                        <phase>integration-test</phase>
                         <goals>
-                            <goal>test</goal>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
                         </goals>
-                        <configuration>
-                            <includes>
-                                <include>**/*IT.java</include>
-                                <include>**/*Test.java</include>
-                            </includes>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
## Summary

- build-logic PR #655 (merged 2026-07-16) changed `os-extension-test.yml` to run `mvn verify -DskipITs=true` instead of only running through the `test` phase.
- `-DskipITs` is a `maven-failsafe-plugin` property — it has **no effect** on `maven-surefire-plugin`.
- This pom.xml was binding a second surefire execution to the `integration-test` phase. So when `mvn verify` ran, that surefire execution fired unconditionally, tried to connect to the CosmosDB emulator at `localhost:8081`, and failed because the nightly workflow never starts one.
- Every nightly run from July 17 onward has failed for this reason. The triggering Dependabot commit (PR #447, `aws-actions` bump) was unrelated.

**Fix:** replace the surefire `integration-tests` execution with `maven-failsafe-plugin` using the standard `integration-test` + `verify` goals. `-DskipITs=true` from the workflow now correctly suppresses IT execution when `runIntegrationTests=false`.

## Test plan

- [ ] Nightly build passes with this change (unit tests run in `test` phase, ITs skipped via `-DskipITs=true`)
- [ ] When ITs are enabled (`runIntegrationTests=true`), the `*IT` classes run under failsafe as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)